### PR TITLE
Stabilize active mesh

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ exclude = ["test", "docker-compose.yml", "Dockerfile"]
 
 [dependencies]
 futures = "0.3.18"
-libp2p-core = "0.31.0"
-libp2p-swarm = "0.33.0"
+libp2p-core = "0.32.0"
+libp2p-swarm = "0.35.0"
 multiaddr = "0.13.0"
 tracing = "0.1.29"
 prost = "0.9"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
+# syntax=docker/dockerfile:1.3
 FROM nwtgck/rust-musl-builder:latest AS rust-build
-ADD . /code
-RUN sudo chown -R rust /code
-RUN cd /code && cargo build --release --target x86_64-unknown-linux-musl
-RUN cd /code/test/audit && cargo build --release --target x86_64-unknown-linux-musl
-RUN cd /code/test/node && cargo build --release --target x86_64-unknown-linux-musl
+COPY --chown=rust:rust . /code
+RUN --mount=type=cache,target=/home/rust/.cargo/registry,uid=1000,gid=1000 --mount=type=cache,target=/code/target,uid=1000,gid=1000 cd /code && cargo build --release --target x86_64-unknown-linux-musl
+RUN --mount=type=cache,target=/home/rust/.cargo/registry,uid=1000,gid=1000 --mount=type=cache,target=/code/test/audit/target,uid=1000,gid=1000 cd /code/test/audit && cargo build --release --target x86_64-unknown-linux-musl && cp /code/test/audit/target/x86_64-unknown-linux-musl/release/audit-node /home/rust
+RUN --mount=type=cache,target=/home/rust/.cargo/registry,uid=1000,gid=1000 --mount=type=cache,target=/code/test/node/target,uid=1000,gid=1000 cd /code/test/node && cargo build --release --target x86_64-unknown-linux-musl && cp /code/test/node/target/x86_64-unknown-linux-musl/release/episub-node /home/rust
 
 
 FROM alpine:latest
-WORKDIR /home
-COPY --from=rust-build /code/test/audit/target/x86_64-unknown-linux-musl/release/audit-node .
-COPY --from=rust-build /code/test/node/target/x86_64-unknown-linux-musl/release/episub-node .
+WORKDIR /home/rust
+COPY --from=rust-build /home/rust/audit-node .
+COPY --from=rust-build /home/rust/episub-node .
 COPY --from=rust-build /code/test/audit/assets ./assets
 
 EXPOSE 4001

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Originally [speced by @vyzo](https://github.com/libp2p/specs/blob/master/pubsub/
 ## Running a topology with 201 peers:
 
 ```
-$ docker-compose up --scale node_n=200 --remove-orphans
+$ docker-compose up --scale node_t0=200 --remove-orphans
 ```
 
 
@@ -32,7 +32,7 @@ $ docker-compose up -d node_0
 You should see it immediately showing up in the labs page, then start 50 peer nodes and watch the network discover itself.
 
 ```
-$ docker-compose up --scale node_n=50
+$ docker-compose up --scale node_t0=50
 ```
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,10 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ./episub-node --topic t0 --audit 172.28.1.1:9000 -v --size 100 --sender
+    command: ./episub-node -t t0 -t t1 --audit 172.28.1.1:9000 --size 100 --sender
     environment:
       - RUST_BACKTRACE=1
+      - "RUST_LOG=debug,netlink_proto=info"
     depends_on:
       node_audit: # wait for audit node to start
         condition: service_started
@@ -33,14 +34,16 @@ services:
         ipv4_address: 172.28.1.2
 
   # peer node
-  # when running use --scale node_n=N, where N is between 1-1000
-  node_n:
+  # when running use --scale node_t0=N, where N is between 1-1000
+  node_t0:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t0 -v --size 100
+    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t0 --size 100
     environment:
       - RUST_BACKTRACE=1
+      - "RUST_LOG=debug,netlink_proto=info"
+    depends_on:
     depends_on:
       node_audit: # wait for audit node to start
         condition: service_started
@@ -49,6 +52,21 @@ services:
     networks:
       testing_net:
         
+  node_t1:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t1 --size 100
+    environment:
+      - RUST_BACKTRACE=1
+      - "RUST_LOG=debug,netlink_proto=info"
+    depends_on:
+      node_audit: # wait for audit node to start
+        condition: service_started
+      node_0: # wait for bootstrap node to start
+        condition: service_started
+    networks:
+      testing_net:
 
 networks:
   testing_net:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ./episub-node -t t0 -t t1 --audit 172.28.1.1:9000 --size 100 --sender
+    command: ./episub-node -t t0 -t t1 --audit 172.28.1.1:9000 --size 8 --sender
     environment:
       - RUST_BACKTRACE=1
       - "RUST_LOG=debug,netlink_proto=info"
@@ -39,7 +39,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t0 --size 100
+    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t0 --size 8
     environment:
       - RUST_BACKTRACE=1
       - "RUST_LOG=debug,netlink_proto=info"
@@ -56,7 +56,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t1 --size 100
+    command: ./episub-node --bootstrap /ip4/172.28.1.2/tcp/4001 --audit 172.28.1.1:9000 --topic t1 --size 8
     environment:
       - RUST_BACKTRACE=1
       - "RUST_LOG=debug,netlink_proto=info"

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -3,6 +3,7 @@ use crate::{
   topic::TopicMesh, view::AddressablePeer,
 };
 use futures::FutureExt;
+use libp2p_core::multiaddr::Protocol;
 use libp2p_core::{
   connection::{ConnectionId, ListenerId},
   ConnectedPoint, Multiaddr, PeerId,
@@ -11,7 +12,6 @@ use libp2p_swarm::{
   CloseConnection, DialError, NetworkBehaviour, NetworkBehaviourAction,
   NotifyHandler, PollParameters,
 };
-use multiaddr::Protocol;
 use rand::Rng;
 use std::{
   collections::{HashMap, HashSet, VecDeque},
@@ -212,10 +212,10 @@ impl Episub {
 }
 
 impl NetworkBehaviour for Episub {
-  type ProtocolsHandler = EpisubHandler;
+  type ConnectionHandler = EpisubHandler;
   type OutEvent = EpisubEvent;
 
-  fn new_handler(&mut self) -> Self::ProtocolsHandler {
+  fn new_handler(&mut self) -> Self::ConnectionHandler {
     EpisubHandler::new(self.config.max_transmit_size, false)
   }
 
@@ -225,6 +225,7 @@ impl NetworkBehaviour for Episub {
     connection: &ConnectionId,
     endpoint: &ConnectedPoint,
     _failed_addresses: Option<&Vec<Multiaddr>>,
+    _other_established: usize,
   ) {
     if self.banned_peers.contains(peer_id) {
       self.force_disconnect(*peer_id, *connection);
@@ -289,7 +290,7 @@ impl NetworkBehaviour for Episub {
   fn inject_dial_failure(
     &mut self,
     peer_id: Option<PeerId>,
-    _: Self::ProtocolsHandler,
+    _: Self::ConnectionHandler,
     error: &DialError,
   ) {
     if !matches!(error, DialError::DialPeerConditionFalse(_)) {
@@ -309,6 +310,7 @@ impl NetworkBehaviour for Episub {
     _: &ConnectionId,
     endpoint: &ConnectedPoint,
     _: EpisubHandler,
+    _remaining_established: usize,
   ) {
     debug!(
       "Connection to peer {} closed on endpoint {:?}",
@@ -395,7 +397,7 @@ impl NetworkBehaviour for Episub {
     &mut self,
     cx: &mut Context<'_>,
     params: &mut impl PollParameters,
-  ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ProtocolsHandler>> {
+  ) -> Poll<NetworkBehaviourAction<Self::OutEvent, Self::ConnectionHandler>> {
     // update local peer identity and addresses
     self.update_local_node_info(params);
 

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -19,7 +19,7 @@ use std::{
   net::{Ipv4Addr, Ipv6Addr},
   task::{Context, Poll},
 };
-use tracing::{debug, trace, warn};
+use tracing::{debug, info, trace, warn};
 
 /// Event that can be emitted by the episub behaviour.
 #[derive(Debug)]
@@ -30,7 +30,7 @@ pub enum EpisubEvent {
     payload: Vec<u8>,
   },
   Subscribed(String),
-  Unsubscibed(String),
+  Unsubscribed(String),
   PeerAdded(PeerId),
   PeerRemoved(PeerId),
 }
@@ -121,7 +121,7 @@ impl Episub {
   /// Subscribes to a gossip topic.
   ///
   /// Gossip topics are isolated clusters of nodes that gossip information, each topic
-  /// maintins a separate HyParView of topic member nodes and does not interact with
+  /// maintains a separate HyParView of topic member nodes and does not interact with
   /// nodes from other topics (unless two nodes are subscribed to the same topic, but
   /// even then, they are not aware of the dual subscription).
   ///
@@ -189,7 +189,7 @@ impl Episub {
       self
         .out_events
         .push_back(EpisubNetworkBehaviourAction::GenerateEvent(
-          EpisubEvent::Unsubscibed(topic),
+          EpisubEvent::Unsubscribed(topic),
         ));
 
       true
@@ -377,6 +377,7 @@ impl NetworkBehaviour for Episub {
       // then closing connection to the peer. That will also remove
       // this node from the requesting peer's passive view, so we won't
       // be bothered again by this peer for this topic.
+      info!("RPC with wrong topic {} - forcing disconnect", &event.topic);
       self
         .out_events
         .push_back(EpisubNetworkBehaviourAction::NotifyHandler {

--- a/src/behaviour.rs
+++ b/src/behaviour.rs
@@ -261,7 +261,7 @@ impl NetworkBehaviour for Episub {
 
       // make sure that we know who we are and how we can be reached.
       if self.local_node.is_some() {
-        // for each topic that has zero active nodes,
+        // for each topic that hasn't enough active nodes,
         // send a join request to any dialer
         self.request_join_for_starving_topics(*peer_id);
       } else {
@@ -491,7 +491,7 @@ impl Episub {
   }
 
   fn request_join_for_starving_topics(&mut self, peer: PeerId) {
-    // for each topic that has zero active nodes,
+    // for each topic with view that has not reached minimum size of active nodes,
     // send a join request to any dialer
     self
       .topics

--- a/src/config.rs
+++ b/src/config.rs
@@ -82,9 +82,18 @@ pub struct Config {
 }
 
 impl Config {
+  /// A node is considered overconnected when it's active view size is at least `max_active_view_size`
   pub fn max_active_view_size(&self) -> usize {
     ((self.network_size as f64).log2() + self.active_view_factor as f64).round()
       as usize
+  }
+
+  /// A node is considered starving when it's active view size is less then `min_active_view_size`
+  ///
+  /// It will try to maintain half of `max_active_view_size` to achieve minimum level of connection redundancy. Another half is reserved for peering connections from other nodes.
+  /// Two thresholds allow to avoid cyclical connections and disconnections when new nodes are connected to a group of overconnected nodes.
+  pub fn min_active_view_size(&self) -> usize {
+    self.max_active_view_size().div_euclid(2).max(1)
   }
 
   pub fn max_passive_view_size(&self) -> usize {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -5,9 +5,10 @@ use asynchronous_codec::Framed;
 use futures::{Sink, StreamExt};
 use libp2p_core::{InboundUpgrade, OutboundUpgrade};
 use libp2p_swarm::{
-  KeepAlive, NegotiatedSubstream, ProtocolsHandler, ProtocolsHandlerEvent,
-  ProtocolsHandlerUpgrErr, SubstreamProtocol,
+  KeepAlive, NegotiatedSubstream, ConnectionHandler, 
+  SubstreamProtocol, ConnectionHandlerEvent, ConnectionHandlerUpgrErr
 };
+use libp2p_swarm::{};
 use std::{
   collections::VecDeque,
   io,
@@ -57,11 +58,11 @@ pub struct EpisubHandler {
   outbound_queue: VecDeque<rpc::Rpc>,
 }
 
-type EpisubHandlerEvent = ProtocolsHandlerEvent<
-  <EpisubHandler as ProtocolsHandler>::OutboundProtocol,
-  <EpisubHandler as ProtocolsHandler>::OutboundOpenInfo,
-  <EpisubHandler as ProtocolsHandler>::OutEvent,
-  <EpisubHandler as ProtocolsHandler>::Error,
+type EpisubHandlerEvent = ConnectionHandlerEvent<
+  <EpisubHandler as ConnectionHandler>::OutboundProtocol,
+  <EpisubHandler as ConnectionHandler>::OutboundOpenInfo,
+  <EpisubHandler as ConnectionHandler>::OutEvent,
+  <EpisubHandler as ConnectionHandler>::Error,
 >;
 
 impl EpisubHandler {
@@ -83,7 +84,7 @@ impl EpisubHandler {
   }
 }
 
-impl ProtocolsHandler for EpisubHandler {
+impl ConnectionHandler for EpisubHandler {
   type InEvent = rpc::Rpc;
   type OutEvent = rpc::Rpc;
   type Error = EpisubHandlerError;
@@ -139,7 +140,7 @@ impl ProtocolsHandler for EpisubHandler {
   fn inject_dial_upgrade_error(
     &mut self,
     _: Self::OutboundOpenInfo,
-    error: ProtocolsHandlerUpgrErr<
+    error: ConnectionHandlerUpgrErr<
       <Self::OutboundProtocol as OutboundUpgrade<NegotiatedSubstream>>::Error,
     >,
   ) {
@@ -181,7 +182,7 @@ impl EpisubHandler {
             Poll::Ready(Some(Ok(message))) => {
               self.inbound_substream =
                 Some(InboundSubstreamState::WaitingInput(substream));
-              return Poll::Ready(ProtocolsHandlerEvent::Custom(message));
+              return Poll::Ready(ConnectionHandlerEvent::Custom(message));
             }
             Poll::Ready(Some(Err(error))) => {
               warn!("inbound stream error: {:?}", error);
@@ -267,13 +268,13 @@ impl EpisubHandler {
                 }
                 Err(e) => {
                   error!("Error sending message: {}", e);
-                  return Poll::Ready(ProtocolsHandlerEvent::Close(e));
+                  return Poll::Ready(ConnectionHandlerEvent::Close(e));
                 }
               }
             }
             Poll::Ready(Err(e)) => {
               error!("outbound substream error while sending message: {:?}", e);
-              return Poll::Ready(ProtocolsHandlerEvent::Close(e));
+              return Poll::Ready(ConnectionHandlerEvent::Close(e));
             }
             Poll::Pending => {
               self.keep_alive = KeepAlive::Yes;
@@ -290,7 +291,7 @@ impl EpisubHandler {
                 Some(OutboundSubstreamState::WaitingOutput(substream));
             }
             Poll::Ready(Err(e)) => {
-              return Poll::Ready(ProtocolsHandlerEvent::Close(e))
+              return Poll::Ready(ConnectionHandlerEvent::Close(e))
             }
             Poll::Pending => {
               self.keep_alive = KeepAlive::Yes;
@@ -311,7 +312,7 @@ impl EpisubHandler {
             }
             Poll::Ready(Err(e)) => {
               warn!("Outbound substream error while closing: {:?}", e);
-              return Poll::Ready(ProtocolsHandlerEvent::Close(
+              return Poll::Ready(ConnectionHandlerEvent::Close(
                 io::Error::new(
                   io::ErrorKind::BrokenPipe,
                   "Failed to close outbound substream",
@@ -339,7 +340,7 @@ impl EpisubHandler {
           self.outbound_substream =
             Some(OutboundSubstreamState::SubstreamRequested);
           return Poll::Ready(
-            ProtocolsHandlerEvent::OutboundSubstreamRequest {
+            ConnectionHandlerEvent::OutboundSubstreamRequest {
               protocol: self.listen_protocol.clone(),
             },
           );

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -221,20 +221,22 @@ impl PlumTree {
       .map(|m| m.into())
       .collect();
 
-    self.lazy.iter().for_each(|p| {
-      self
-        .out_events
-        .push_back(EpisubNetworkBehaviourAction::NotifyHandler {
-          peer_id: *p,
-          handler: NotifyHandler::Any,
-          event: rpc::Rpc {
-            topic: self.topic.clone(),
-            action: Some(rpc::rpc::Action::Ihave(rpc::IHave {
-              ihaves: received.clone(),
-            })),
-          },
-        })
-    });
+    if !received.is_empty() {
+      self.lazy.iter().for_each(|p| {
+        self
+          .out_events
+          .push_back(EpisubNetworkBehaviourAction::NotifyHandler {
+            peer_id: *p,
+            handler: NotifyHandler::Any,
+            event: rpc::Rpc {
+              topic: self.topic.clone(),
+              action: Some(rpc::rpc::Action::Ihave(rpc::IHave {
+                ihaves: received.clone(),
+              })),
+            },
+          })
+      });
+    }
   }
 
   fn prune_history(&mut self) {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -187,7 +187,7 @@ impl PlumTree {
   }
 
   pub fn inject_graft(&mut self, peer_id: PeerId, ids: Vec<u128>) {
-    // updgrade to eager node after graft
+    // upgrade to eager node after graft
     self.lazy.remove(&peer_id);
     self.eager.insert(peer_id);
 

--- a/src/view.rs
+++ b/src/view.rs
@@ -117,7 +117,7 @@ impl HyParView {
   /// a random node from the active view and makes space for the new
   /// node.
   fn free_up_active_slot(&mut self) {
-    if self.starved() {
+    if !self.starved() {
       let random = self.passive.iter().choose(&mut rand::thread_rng()).cloned();
       if let Some(random) = random {
         debug!(

--- a/src/view.rs
+++ b/src/view.rs
@@ -6,12 +6,11 @@ use crate::{
   handler::EpisubHandler, rpc, EpisubEvent,
 };
 use futures::Future;
-use libp2p_core::PeerId;
+use libp2p_core::{Multiaddr, PeerId};
 use libp2p_swarm::{
   dial_opts::{DialOpts, PeerCondition},
   NotifyHandler,
 };
-use multiaddr::Multiaddr;
 use rand::prelude::IteratorRandom;
 use std::{
   collections::{HashSet, VecDeque},

--- a/test/audit/Cargo.toml
+++ b/test/audit/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["network-programming", "asynchornous"]
 [dependencies]
 libp2p-episub = { path = "../../" }
 
-libp2p = "0.41.0"
+libp2p = "0.44.0"
 anyhow = "1.0.51"
 tracing = "0.1.29"
 headers = "0.3"

--- a/test/node/Cargo.toml
+++ b/test/node/Cargo.toml
@@ -17,9 +17,9 @@ futures = "0.3.18"
 chrono = "0.4.19"
 structopt = "0.3"
 tracing = "0.1.29"
-tracing-subscriber = "0.3.3"
+tracing-subscriber = { version = "0.3.3", features = ["env-filter"] }
 
-libp2p = { version = "0.41.0" }
+libp2p = { version = "0.44.0" }
 
 anyhow = { version = "1.0.51" }
 tokio = { version = "1.14.0", features = ["full"] }


### PR DESCRIPTION
There are multiple improvements grouped by commits

* updated libp2p dependencies
* test node binary uses RUST_LOG for module-level verbosity configuration
* Docker build uses cache volumes to speedup dev iterations with consecutive builds, docker-compose `node_tX` services for two topics `t0` and `t1`. `node_0` sends to both topics in round robin.
* slots in active views are freed only when a node is not starving - fixed wrong condition
* iHave message is not sent when there were no recently received messages
* NEIGHBOUR request is ignored when requesting node is already in active view. This fixed cyclical mesh instability for three node mesh (node_0 + 2x node_t0)
* introduced the second threshold for active view size - `min_active_view_size` which is a half from `max_active_view_size`. `!starved` became `overconnected`. `starved` node now has active view with size less than `min_active_view_size`. The second half of active view is reserved for peering connections from other nodes and gives some stability range when no new connections or disconnections are required. Two thresholds are equivalents of `lo` and `hi` node degree in gossipsub.
This change fixed cyclical mesh instability for 16 node mesh (node_0 + 15x node_t0).

I think it's possible to configure `min_active_view_size` instead of estimated `size` of mesh network. Then other parameters and conditions like `max_active_view_size` or `starved` would need only multiplications and summations that are cheaper to compute than `log`. And it's easier to reason about required per node connection redundancy level instead of potentially variable network size.